### PR TITLE
feature(signup):implement account registration

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,5 @@
+NODE_ENV= # Your node env. Ideally development
+
+DB_USERNAME= # Your database username
+DB_PASSWORD= # The corresponding database password
+DB_NAME= # Your database name

--- a/api/README.md
+++ b/api/README.md
@@ -11,4 +11,4 @@
 
 ### Notes
 
-- The server runs on `http://localhost:8051` on default
+- The server runs on `http://localhost:8050` on default

--- a/api/knexfile.js
+++ b/api/knexfile.js
@@ -1,0 +1,61 @@
+// Update with your config settings.
+require('dotenv').config();
+
+module.exports = {
+  development: {
+    client: 'mysql2',
+    connection: {
+      database: process.env.DB_NAME,
+      user: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: __dirname + '/src/database/migrations'
+    },
+    seeds: {
+      directory: __dirname + '/src/database/seeds'
+    },
+  },
+
+  staging: {
+    client: 'mysql2',
+    connection: {
+      database: process.env.DB_NAME,
+      user: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: __dirname + '/src/database/migrations'
+    },
+    seeds: {
+      directory: __dirname + '/src/database/seeds'
+    },
+  },
+
+  production: {
+    client: 'mysql2',
+    connection: process.env.DATABASE_URL,
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: __dirname + '/src/database/migrations'
+    },
+    seeds: {
+      directory: __dirname + '/src/database/seeds'
+    },
+  }
+
+};

--- a/api/src/controllers/AuthController.js
+++ b/api/src/controllers/AuthController.js
@@ -18,6 +18,10 @@ export default {
                 throw new ClientError('An account exists with this email');
             }
 
+            if (body.password !== body.confirm_password) {
+                throw new ClientError('Passwords do not match');
+            }
+
             const encryptedPassword = await _bcrypt.hash(body.password);
             const confirmationToken = crypto.createHmac('sha256', JSON.stringify({ email: body.email }), { encoding: 'utf-8' }).update('token').digest('hex');
 
@@ -32,7 +36,7 @@ export default {
                     confirmation_token: confirmationToken
                 }, ['id', 'email']);            
 
-            const [profile, subscriber] = await Promise.all([
+            await Promise.all([
                 knex('user_profiles')
                     .transacting(transaction)
                     .insert({

--- a/api/src/controllers/AuthController.js
+++ b/api/src/controllers/AuthController.js
@@ -1,0 +1,108 @@
+import crypto from 'crypto';
+import knex from '../database';
+import { ClientError } from '../errors';
+import _bcrypt from '../utils/_bcrypt';
+import { makeToken } from '../utils/_jwt';
+import mailer from '../utils/mailer';
+import env from '../utils/env';
+
+export default {
+    async createAccount(req, res, next) {
+        const { body } = req;
+        const transaction = await knex.transaction();
+
+        try {
+            const userWithSameEmail = await knex.first('id').from('users').where('email', body.email);
+
+            if (userWithSameEmail) {
+                throw new ClientError('An account exists with this email');
+            }
+
+            const encryptedPassword = await _bcrypt.hash(body.password);
+            const confirmationToken = crypto.createHmac('sha256', JSON.stringify({ email: body.email }), { encoding: 'utf-8' }).update('token').digest('hex');
+
+            const permission = await knex.first('id').from('permissions').where('label', 'member');
+
+            const [userId] = await knex('users')
+                .transacting(transaction)
+                .insert({
+                    email: body.email,
+                    password: encryptedPassword,
+                    permission_id: permission.id,
+                    confirmation_token: confirmationToken
+                }, ['id', 'email']);            
+
+            const [profile, subscriber] = await Promise.all([
+                knex('user_profiles')
+                    .transacting(transaction)
+                    .insert({
+                        first_name: body.first_name,
+                        last_name: body.last_name,
+                        user_id: userId
+                    }, ['last_name', 'first_name']),
+
+                knex('subscribers')
+                    .transacting(transaction)
+                    .insert({
+                        email: body.email,
+                    })
+            ]);
+
+            await mailer.sendAccountVerification({
+                first_name: body.first_name,
+                last_name: body.last_name,
+                email: body.email,
+                verification_url: `${env.get('FRONTEND_BASEURL')}/auth/verify?token=${confirmationToken}`
+            });
+
+            await transaction.commit();
+
+            res.status(201).json({
+                status: 'success',
+                message: 'Account successfully created',
+                data: {
+                    id: userId,
+                    email: body.email
+                }
+            });
+        } catch (error) {
+            await transaction.rollback(error);
+            next(error);
+        }
+    },
+
+    /**
+     * Sign in a user
+     */
+    async signIn(req, res, next) {
+        const { body } = req;
+        const genericErrorMsg = 'Email or password is incorrect';
+
+        try {
+            const user = await knex.first().from('users').where('email', body.email || 1);
+
+            if (!user) {
+                throw new ClientError(genericErrorMsg);
+            }
+
+            const passwordMatch = await _bcrypt.compare(body.password, user.password);
+
+            if (!passwordMatch) {
+                throw new ClientError(genericErrorMsg);
+            }
+
+            const payload = { id: user.id, email: user.email };
+
+            res.status(202).json({
+                status: 'success',
+                message: 'Signed in successfully',
+                data: {
+                    ...payload,
+                    token: makeToken(payload)
+                }
+            })
+        } catch (error) {
+            next(error);
+        }
+    }
+};

--- a/api/src/database/index.js
+++ b/api/src/database/index.js
@@ -4,7 +4,6 @@ import knex from 'knex';
 dotenv.config();
 
 const connection = process.env.DB_CONNECTION_STRING || {
-  host : process.env.DB_HOST || '127.0.0.1',
   user : process.env.DB_USERNAME,
   password : process.env.DB_PASSWORD,
   database : process.env.DB_NAME
@@ -15,6 +14,6 @@ const connection = process.env.DB_CONNECTION_STRING || {
  * A knex Client instance
  */
 export default knex({
-  client: 'mysql',
+  client: 'mysql2',
   connection,
 });

--- a/api/src/database/migrations/20201219212802_create_permissions.js
+++ b/api/src/database/migrations/20201219212802_create_permissions.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('permissions', (table) => {
+      table.increments();
+      table.string('label').notNullable();
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('permissions');
+};

--- a/api/src/database/migrations/20201219213833_create_users.js
+++ b/api/src/database/migrations/20201219213833_create_users.js
@@ -1,0 +1,24 @@
+
+
+exports.up = function(knex) {
+    return knex.schema.createTable('users', (table) => {
+      table.increments();
+      table.string('email').notNullable();
+      table.string('password').notNullable();
+      table.string('confirmation_token');
+      table.timestamp('verified_at');
+      table.timestamp('last_logged_in_at');
+      table.timestamp('deactivated_at');
+      table.integer('permission_id').unsigned().notNullable();
+      table.integer('deactivated_by').unsigned();
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+
+      table.foreign('permission_id').references('id').inTable('permissions');
+      table.foreign('deactivated_by').references('id').inTable('users');
+    });
+};
+
+exports.down = function(knex) {
+    return knex.schema.dropTableIfExists('users');
+};

--- a/api/src/database/migrations/20201220001607_create_user_profiles.js
+++ b/api/src/database/migrations/20201220001607_create_user_profiles.js
@@ -1,0 +1,19 @@
+exports.up = function(knex) {
+    return knex.schema.createTable('user_profiles', (table) => {
+    table.increments();
+    table.string('first_name').notNullable();
+    table.string('last_name').notNullable();
+    table.string('avatar');
+    table.string('gender');
+    table.integer('user_id').unsigned().notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+
+    table.foreign('user_id').references('id').inTable('users');
+    });
+};
+  
+exports.down = function(knex) {
+    return knex.schema.dropTableIfExists('user_profiles');
+};
+

--- a/api/src/database/migrations/20201220023801_create_subscribers.js
+++ b/api/src/database/migrations/20201220023801_create_subscribers.js
@@ -1,0 +1,15 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('subscribers', (table) => {
+      table.increments();
+      table.string('email');
+      table.boolean('allow_newsletters').defaultTo(true);
+      table.boolean('allow_promotions').defaultTo(true);
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('subscribers');
+};

--- a/api/src/database/seeds/populate_permissions.js
+++ b/api/src/database/seeds/populate_permissions.js
@@ -1,0 +1,13 @@
+
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('permissions').del()
+    .then(function () {
+      // Inserts seed entries
+      return knex('permissions').insert([
+        {id: 1, label: 'admin'},
+        {id: 2, label: 'doctor'},
+        {id: 3, label: 'member'},
+      ]);
+    });
+};

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -81,7 +81,7 @@ app.use((err, req, res, next) => {
     });
 });
 
-app.set('PORT', process.env.PORT || 8051);
+app.set('PORT', process.env.PORT || 8050);
 
 app.listen(app.get('PORT'), () => {
     console.log(`Server is now running at port ${app.get('PORT')}`)

--- a/api/src/routes/v1/AuthRoute.js
+++ b/api/src/routes/v1/AuthRoute.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import AuthController from '../../controllers/AuthController';
+
+const router = Router();
+
+router.post('/signup', AuthController.createAccount);
+router.post('/signin', AuthController.signIn);
+
+export default router;

--- a/api/src/routes/v1/index.js
+++ b/api/src/routes/v1/index.js
@@ -1,6 +1,9 @@
 import { Router } from 'express';
+import AuthRoute from './AuthRoute';
 
 const router = Router();
+
+router.use('/auth', AuthRoute);
 
 router.use('/', (req, res) => {
     res.status(200).json({

--- a/api/src/templates/mails/account-verification.hbs
+++ b/api/src/templates/mails/account-verification.hbs
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>HealthCare - Account Verification</title>
+        <style>
+            body {
+                max-width: 900px;
+            }
+
+            .account-verification {
+                width: 100%;
+                margin: auto;
+                text-align: center;
+            }
+
+            table {
+                
+            }
+
+            .btn.verification_url {
+                width: 100%;
+                display: block;
+                max-width: 400px;
+                margin: auto;
+            }
+
+            footer {
+                margin-top: 3em;
+            }
+        </style>
+    </head>
+
+    <body>
+        <div>
+            <header>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>
+                              <h1>Thanks for creating an account! Verify your email</h1>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </header>
+
+            <main class="account-verificaition">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <h4>Hi, <span class="capitalize">{{first_name}}</span></h4>
+
+                                <p class="text-">Please click the button below to verify your account</p>
+
+                                <br />
+                                <br />
+
+                                <a
+                                    class="block verification_url btn btn--primary btn--lg" 
+                                    rel="noreferrer"
+                                    href={{verification_url}}
+                                    target="_blank"
+                                >Verify Account</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </main>
+
+            <footer>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <h1>Welcome to HealthCare!</h1>
+
+                                <p>This mail is intended for <span class="capitalize">{{first_name}} {{last_name}}</span>. Please ignore if it's not you.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </footer>
+        </div>
+    </body>
+</html>

--- a/api/src/utils/env.js
+++ b/api/src/utils/env.js
@@ -1,0 +1,13 @@
+require('dotenv').config();
+
+
+export default {
+    /**
+     * Attempts to return the value of an environment variable
+     * @param { string } variable - An environment variable name
+     * @returns { string | undefined } the value of an environment variable if it exist. Otherwise, it returns `undefined`
+     */
+    get(variable) {
+        return process.env[variable];
+    }
+}

--- a/api/src/utils/mailer.js
+++ b/api/src/utils/mailer.js
@@ -1,0 +1,84 @@
+import path from 'path';
+import fs from 'fs';
+import dotenv from 'dotenv';
+import nodemailer from 'nodemailer';
+import handlebars from 'handlebars';
+
+dotenv.config();
+
+class Mailer {
+    /**
+     * A mail service
+     */
+    constructor() {
+        this.transporter = nodemailer.createTransport({
+            host: process.env.MAIL_HOST,
+            port: process.env.MAIL_PORT || 587,
+            secure: false, // upgrade later with STARTTLS
+            auth: {
+                user: process.env.MAIL_USERNAME,
+                pass: process.env.MAIL_PASSWORD
+            }
+        });
+
+        this.from = '"The HealthCare Team" <snettpro@gmail.com>';
+    }
+
+    /**
+     * Sends an email
+     * @param { object } options - The email options
+     * @param { string[] } options.recipients - An array of the email recipients
+     * @param { string } options.subject - The subject of the mail
+     * @param { string } options.text - A plaintext format of the mail
+     * @param { HTMLElement } options.html - A html format of the mail
+     */
+    async send({ recipients, subject, text, html }) {
+        try {
+            await this.transporter.sendMail({
+                from: this.from,
+                to: recipients,
+                subject,
+                text,
+                html
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+   
+    /**
+     * Send verification email
+     * @param { object } details - An object containing the user's details and the verification link
+     */
+    async sendAccountVerification(details) {
+        const template = this.composeTemplate('account-verification', details);
+        console.log(template);
+        try {
+            await this.send({
+                recipients: [details.email],
+                subject: 'HealthCare - Account Verification',
+                html: template
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Compose and return the HTML format of a mail
+     * @param { string } templateName - The name of a template file in the `mailTemplates` directory
+     * @param { object } data - An object containing dynamic information to be used
+     * in the composition of an email
+     */
+    composeTemplate(templateName, data) {
+        const templatePath = path.join(__dirname, '../templates/mails', `/${templateName}.hbs`);
+        const templateFile = fs.readFileSync(templatePath).toString();
+
+        console.log(templateFile);
+
+        const template = handlebars.compile(templateFile);
+        return template(data);
+    }
+}
+
+export default new Mailer();


### PR DESCRIPTION
#### What does this PR do?
Implement the account registration feature

#### Description of Task to be completed?
- implement the `/auth/signup` endpoint to enable the registration of user accounts

- send verification mail to new users

- add new users to the subscriber list
#### How should this be manually tested?
- clone the repository
- cd into the project directory and run `cd api` to CD into the `api` directory
- see the README.md file in the `api` directory for the preliminary steps
- ensure that a mysql database in installed and running on your device
- send a POST request to `/auth/signup`. The payload of the request must look like so:
```
{
 "first_name": <string>,
 "last_name": <string>,
 "email": <string>,
 "password": <string>,
 "confirm_password": <string>
}
```

#### Any background context you want to provide?
- All fields in the payload are required.

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A
#### Questions: