### PR TITLE
feature(course):validate course lecture data

### DIFF
--- a/api/src/routes/v1/CourseRoute.js
+++ b/api/src/routes/v1/CourseRoute.js
@@ -4,6 +4,7 @@ import pagination from '../../middlewares/pagination';
 import CourseCategoryValidator from '../../validators/courseCategory';
 import CourseValidator from '../../validators/course';
 import CourseModuleValidator from '../../validators/courseModule';
+import CourseLectureValidator from '../../validators/courseLecture';
 import CourseCategoryController from '../../controllers/CourseCategoryController';
 import CourseController from '../../controllers/CourseController';
 
@@ -39,19 +40,19 @@ router.route('/:slug/modules/:moduleId/position')
 
 // COURSE LECTURES
 router.route('/:slug/modules/:moduleId/lectures')
-    .post(authenticate, CourseModuleValidator.validateBodyOnCreate, CourseController.createCourseLecture)
+    .post(authenticate, CourseLectureValidator.validateBodyOnCreate, CourseController.createCourseLecture)
     .get(pagination, CourseController.fetchLecturesInModule);
 
 router.route('/:slug/lectures/:lectureId')
     .get(pagination, CourseController.fetchLecture)
-    .patch(authenticate, CourseModuleValidator.validateBodyOnUpdate, CourseController.updateCourseLecture)
+    .patch(authenticate, CourseLectureValidator.validateBodyOnUpdate, CourseController.updateCourseLecture)
     .delete(authenticate, CourseController.deleteCourseLecture);
 
 router.route('/:slug/lectures/:lectureId/status')
-    .patch(authenticate, CourseModuleValidator.validateBodyOnStatusUpdate, CourseController.updateLectureStatus);
+    .patch(authenticate, CourseLectureValidator.validateBodyOnStatusUpdate, CourseController.updateLectureStatus);
 
 router.route('/:slug/modules/:moduleId/lectures/:lectureId/position')
-    .patch(authenticate, CourseModuleValidator.validateBodyOnPositionUpdate, CourseController.updateLecturePosition);
+    .patch(authenticate, CourseLectureValidator.validateBodyOnPositionUpdate, CourseController.updateLecturePosition);
 
 // COURSE CATEGORIES
 router.route('/categories')

--- a/api/src/validators/courseLecture.js
+++ b/api/src/validators/courseLecture.js
@@ -1,0 +1,38 @@
+import Joi from 'joi';
+import Validator from '../utils/Validator';
+
+const schemaOnCreate = Joi.object({
+    title: Joi.string().required(),
+    overview: Joi.string().allow(''),
+    text: Joi.string().allow(''),
+    video: Joi.binary().allow(''),
+    downladable_file: Joi.binary().allow(''),
+    allow_preview: Joi.boolean(),
+    is_published: Joi.boolean(),
+});
+
+const schemaOnUpdate = Joi.object({
+    title: Joi.string(),
+    overview: Joi.string().allow(''),
+    text: Joi.string().allow(''),
+    video: Joi.binary().allow(''),
+    downladable_file: Joi.binary().allow(''),
+    allow_preview: Joi.boolean(),
+    is_published: Joi.boolean(),
+});
+
+const schemaOnStatusUpdate = Joi.object({
+    is_published: Joi.boolean().required(),
+});
+
+const schemaOnPositionUpdate = Joi.object({
+    module_id: Joi.number().required(),
+    position: Joi.number().required(),
+});
+
+export default {
+    validateBodyOnCreate: Validator.validateBody(schemaOnCreate),
+    validateBodyOnUpdate: Validator.validateBody(schemaOnUpdate),
+    validateBodyOnStatusUpdate: Validator.validateBody(schemaOnStatusUpdate),
+    validateBodyOnPositionUpdate: Validator.validateBody(schemaOnPositionUpdate),
+}


### PR DESCRIPTION
#### What does this PR do?
Validate course lecture data

#### Description of Task to be completed?
- add data validation on endpoints for creating, updating and positioning course lectures

#### How should this be manually tested?
- clone the repository
- cd into the project directory and run `cd api` to CD into the `api` directory
- see the README.md file in the `api` directory for the preliminary steps
- ensure that a mysql database in installed and running on your device
- see the postman documentation on `Course Lectures`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A
#### Questions: