### PR TITLE
feature(products):implement categories endpoints

### DIFF
--- a/api/src/controllers/ProductCategoryController.js
+++ b/api/src/controllers/ProductCategoryController.js
@@ -1,0 +1,207 @@
+import knex from '../database';
+import { ClientError, NotFoundError, PermissionError } from '../errors';
+
+export default {
+    /**
+     * Creates a product category
+     */
+    async createCategory(req, res, next) {
+        const { body, user } = req;
+
+        try {
+            // if (user.label !== 'admin') {
+            //     throw new PermissionError();
+            // }
+            
+            const duplicateCategory = await knex.first('id')
+            .from('product_categories')
+            .where('label', body.label)
+            .orWhere('label', body.label.toLowerCase());
+            
+            if (duplicateCategory) {
+                throw new ClientError('A category with a similar label already exists');
+            }
+
+            const data = { label: body.label.toLowerCase() };
+            
+            if (body.parent_id) {
+                const parent = await knex.first('id').from('product_categories')
+                    .where('parent_id', body.parent_id)
+
+                if (!parent) {
+                    throw new ClientError('Parent category does not exist');
+                }
+
+                data.parent_id = body.parent_id;
+            }
+
+            await knex('product_categories')
+                .insert(data);
+
+            res.status(201).json({
+                status: 'success',
+                message: 'Category successfully created',
+                data: body
+            })
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    /**
+     * Updates product category
+     */
+    async updateCategory(req, res, next) {
+        const { user, params, body } = req;
+
+        try {
+            // if (user.label !== 'admin') {
+            //     throw new PermissionError();
+            // }
+
+            const category = await knex.first('id')
+                    .from('product_categories')
+                    .where('id', params.id);
+
+            if (!category) {
+                throw new ClientError('Category not found');
+            }
+
+            const data = {};
+
+            if (body.label) {
+                const duplicateCategory = await knex.first('id')
+                .from('product_categories')
+                    .where('id', '!=', params.id)
+                    .andWhere('label', body.label)
+
+                console.log(duplicateCategory);
+                
+                if (duplicateCategory) {
+                    throw new ClientError('A category with a similar label already exists');
+                }
+
+                data.label = body.label.toLowerCase();
+            }
+
+            
+            if (body.parent_id) {
+                const parent = await knex.first('id').from('product_categories')
+                    .where('id', body.parent_id)
+
+                if (!parent) {
+                    throw new ClientError('Parent category does not exist');
+                }
+
+                data.parent_id = body.parent_id;
+            }
+
+            await knex('product_categories')
+                .where('id', params.id)
+                .update({
+                    ...body,
+                    ...data
+                });
+
+            res.status(201).json({
+                status: 'success',
+                message: 'Category successfully updated',
+            })
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    /**
+     * Fetches all product categories
+     */
+    async fetchCategories(req, res, next) {
+        const { query: { active, is_parent } } = req;
+
+        const whereClause = {};
+
+        try {
+            if (active !== undefined)  {
+                whereClause.is_active = active;
+            }
+
+            if (is_parent) {
+                whereClause.parent_id = null
+            }
+
+            const categories = await knex.select('id', 'label', 'parent_id')
+                .from('product_categories')
+                .andWhere(whereClause)
+
+            res.status(200).json({
+                status:'success',
+                message: 'Query successful',
+                data: categories
+            });
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    /**
+     * Fetches all subscategories of a category
+     */
+    async fetchSubcategories(req, res, next) {
+        const { params, query: { active } } = req;
+
+        const whereClause = {};
+
+        try {
+            if (active !== undefined)  {
+                whereClause.is_active = active;
+            }
+
+            const categories = await knex.select('id', 'label', 'parent_id')
+                .from('product_categories as category')
+                .where('parent_id', params.id)
+                .andWhere(whereClause);
+
+            res.status(200).json({
+                status:'success',
+                message: 'Query successful',
+                data: categories
+            });    
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    /**
+     * Deletes a category
+     */
+    async deleteCategory(req, res, next) {
+        const { params } = req;
+
+        try {
+            const category = await knex.first('id')
+                    .from('product_categories')
+                    .where('id', params.id);
+
+            if (!category) {
+                throw new ClientError('Category not found');
+            }
+
+            // const productInCategory = await knex.first().from('products')
+            //     .where('category_id', params.id)
+            //     .orWhere('subcategory_id', params.id);
+
+            // if (productInCategory) {
+            //     throw new PermissionError('Unable to complete. This category is in use. You can make it inactive instead');
+            // }
+
+            await knex.delete().from('product_categories').where('id', params.id);
+
+            res.status(202).json({
+                status: 'success',
+                message: 'Successfully deleted category'
+            });
+        } catch (error) {
+            next(error);
+        }
+    },
+};

--- a/api/src/database/migrations/20210105183917_create_product_categories.js
+++ b/api/src/database/migrations/20210105183917_create_product_categories.js
@@ -1,0 +1,17 @@
+
+exports.up = function(knex) {
+    return knex.schema.createTable('product_categories', (table) => {
+        table.increments();
+        table.string('label').notNullable();
+        table.integer('parent_id').unsigned();
+        table.boolean('is_active').defaultTo(true);
+        table.timestamp('created_at').defaultTo(knex.fn.now());
+        table.timestamp('updated_at').defaultTo(knex.fn.now());
+
+        table.foreign('parent_id').references('id').inTable('product_categories').onDelete('CASCADE').onUpdate('CASCADE');
+    });
+};
+  
+exports.down = function(knex) {
+    return knex.schema.dropTableIfExists('product_categories');
+};

--- a/api/src/database/seeds/populate_permissions.js
+++ b/api/src/database/seeds/populate_permissions.js
@@ -1,7 +1,9 @@
 
-exports.seed = function(knex) {
+exports.seed = async function(knex) {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0');
+
   // Deletes ALL existing entries
-  return knex('permissions').del()
+  await knex('permissions').del()
     .then(function () {
       // Inserts seed entries
       return knex('permissions').insert([
@@ -10,4 +12,6 @@ exports.seed = function(knex) {
         {id: 3, label: 'member'},
       ]);
     });
+
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1');
 };

--- a/api/src/database/seeds/populate_product_categories.js
+++ b/api/src/database/seeds/populate_product_categories.js
@@ -1,18 +1,19 @@
 
 exports.seed = async function(knex) {
   await knex.raw('SET FOREIGN_KEY_CHECKS=0');
-  
+
   // Deletes ALL existing entries
-  await knex('course_categories').del()
+  await knex('product_categories').del()
     .then(function () {
       // Inserts seed entries
-      return knex('course_categories').insert([
+      return knex('product_categories').insert([
         {id: 1, label: 'women medicine'},
         {id: 2, label: 'maternity', parent_id: 1 },
         {id: 3, label: 'breast feeding', parent_id: 1 },
         {id: 4, label: 'child health'},
       ]);
-    })
+    });
 
+  
   await knex.raw('SET FOREIGN_KEY_CHECKS=1');
 };

--- a/api/src/database/seeds/populate_users.js
+++ b/api/src/database/seeds/populate_users.js
@@ -1,8 +1,10 @@
 const _bcrypt = require('../../utils/_bcrypt');
 
-exports.seed = function(knex) {
+exports.seed = async function(knex) {
+  await knex.raw('SET FOREIGN_KEY_CHECKS=0');
+
   // Deletes ALL existing entries in users table
-  return knex('users').del()
+  await knex('users').del()
     .then(async function () {
       const encryptedPassword = await _bcrypt.hash('secret');
       const currentDate = new Date();
@@ -32,7 +34,7 @@ exports.seed = function(knex) {
         },
       ]);
     }).then(function () {
-      // Deletes ALL existing entries in users table
+      // Deletes ALL existing entries in user_profiles table
       return knex('user_profiles').del()
     }).then(function () {
       // Inserts profiles
@@ -60,4 +62,7 @@ exports.seed = function(knex) {
         },
       ]);
     });
+
+  
+  await knex.raw('SET FOREIGN_KEY_CHECKS=1');
 };

--- a/api/src/middlewares/fileHandler.js
+++ b/api/src/middlewares/fileHandler.js
@@ -27,6 +27,7 @@ export default {
      * @param { Array<string> } filter - An array of file types(Ex: image, audio, etc.) allowable on this upload
      */
     single: (fieldName, filter = []) => setup(...filter).single(fieldName),
+
     /**
      * This sets a `files` field on the `Request` object
      * @param { string } fieldName - A key on the request body containing an array of

--- a/api/src/routes/v1/CourseCategoryRoute.js
+++ b/api/src/routes/v1/CourseCategoryRoute.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import authenticate from '../../middlewares/authenticate';
+import pagination from '../../middlewares/paginate';
+import CourseCategoryValidator from '../../validators/category';
+import CourseCategoryController from '../../controllers/CourseCategoryController';
+
+const router = Router();
+
+router.route('/')
+    .post(authenticate, CourseCategoryValidator.validateBodyOnCreate, CourseCategoryController.createCategory)
+    .get(pagination, CourseCategoryController.fetchCategories);
+
+router.route('/:id')
+    .patch(authenticate, CourseCategoryValidator.validateBodyOnUpdate, CourseCategoryController.updateCategory)
+    .delete(authenticate, CourseCategoryController.deleteCategory);
+
+router.route('/:id/subcategories')
+    .get(CourseCategoryController.fetchSubcategories);
+
+export default router;

--- a/api/src/routes/v1/CourseRoute.js
+++ b/api/src/routes/v1/CourseRoute.js
@@ -2,11 +2,9 @@ import { Router } from 'express';
 import authenticate from '../../middlewares/authenticate';
 import pagination from '../../middlewares/paginate';
 import initiateTransaction from '../../middlewares/initiateTransaction';
-import CourseCategoryValidator from '../../validators/courseCategory';
 import CourseValidator from '../../validators/course';
 import CourseModuleValidator from '../../validators/courseModule';
 import CourseLectureValidator from '../../validators/courseLecture';
-import CourseCategoryController from '../../controllers/CourseCategoryController';
 import CourseController from '../../controllers/CourseController';
 
 const router = Router();
@@ -56,17 +54,5 @@ router.route('/:slug/lectures/:lectureId/status')
 
 router.route('/:slug/modules/:moduleId/lectures/:lectureId/position')
     .patch(authenticate, CourseLectureValidator.validateBodyOnPositionUpdate, CourseController.updateLecturePosition);
-
-// COURSE CATEGORIES
-router.route('/categories')
-    .patch(CourseCategoryValidator.validateBodyOnCreate, CourseCategoryController.createCategory)
-    .get(CourseCategoryController.fetchCategories);
-
-router.route('/categories/:id')
-    .patch(CourseCategoryValidator.validateBodyOnUpdate, CourseCategoryController.updateCategory)
-    .delete(CourseCategoryController.deleteCategory);
-
-router.route('/categories/:id/subcategories')
-    .get(CourseCategoryController.fetchSubcategories);
 
 export default router;

--- a/api/src/routes/v1/ProductCategoryRoute.js
+++ b/api/src/routes/v1/ProductCategoryRoute.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import authenticate from '../../middlewares/authenticate';
+import pagination from '../../middlewares/paginate';
+import ProductCategoryValidator from '../../validators/category';
+import ProductCategoryController from '../../controllers/ProductCategoryController';
+
+const router = Router();
+
+router.route('/')
+    .post(authenticate, ProductCategoryValidator.validateBodyOnCreate, ProductCategoryController.createCategory)
+    .get(pagination, ProductCategoryController.fetchCategories);
+
+router.route('/:id')
+    .patch(authenticate, ProductCategoryValidator.validateBodyOnUpdate, ProductCategoryController.updateCategory)
+    .delete(authenticate, ProductCategoryController.deleteCategory);
+
+router.route('/:id/subcategories')
+    .get(ProductCategoryController.fetchSubcategories);
+
+export default router;

--- a/api/src/routes/v1/ProductRoute.js
+++ b/api/src/routes/v1/ProductRoute.js
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import authenticate from '../../middlewares/authenticate';
+import pagination from '../../middlewares/paginate';
+import initiateTransaction from '../../middlewares/initiateTransaction';
+import ProductCategoryValidator from '../../validators/category';
+import CourseValidator from '../../validators/course';
+import CourseModuleValidator from '../../validators/courseModule';
+import CourseLectureValidator from '../../validators/courseLecture';
+import ProductCategoryController from '../../controllers/ProductCategoryController';
+import CourseController from '../../controllers/CourseController';
+
+const router = Router();
+
+router.route('/')
+    .post(authenticate, CourseValidator.validateBodyOnCreate, CourseController.createCourse)
+    .get(pagination, CourseController.fetchCourses);
+
+router.route('/:slug')
+    .patch(authenticate, CourseValidator.validateBodyOnUpdate, CourseController.updateCourse)
+    .get(CourseController.fetchCourse)
+    .delete(authenticate, CourseController.deleteCourse);
+    
+router.route('/:slug/status')
+    .patch(authenticate, CourseValidator.validateBodyOnStatusUpdate, CourseController.updateStatus);
+
+router.route('/:slug/enrollments').post(authenticate, initiateTransaction, CourseController.initiateCourseEnrollment);
+
+// COURSE MODULES
+// router.route('/:slug/modules')
+//     .post(authenticate, CourseModuleValidator.validateBodyOnCreate, CourseController.createCourseModule)
+//     .get(pagination, CourseController.fetchCourseModules);
+
+// router.route('/:slug/modules/:moduleId')
+//     .get(pagination, CourseController.fetchCourseModule)
+//     .patch(authenticate, CourseModuleValidator.validateBodyOnUpdate, CourseController.updateCourseModule)
+//     .delete(authenticate, CourseController.deleteCourseModule);
+
+// router.route('/:slug/modules/:moduleId/status')
+//     .patch(authenticate, CourseModuleValidator.validateBodyOnStatusUpdate, CourseController.updateModuleStatus);
+
+// router.route('/:slug/modules/:moduleId/position')
+//     .patch(authenticate, CourseModuleValidator.validateBodyOnPositionUpdate, CourseController.updateModulePosition);
+
+// COURSE LECTURES
+// router.route('/:slug/modules/:moduleId/lectures')
+//     .post(authenticate, CourseLectureValidator.validateBodyOnCreate, CourseController.createCourseLecture)
+//     .get(pagination, CourseController.fetchLecturesInModule);
+
+// router.route('/:slug/lectures/:lectureId')
+//     .get(pagination, CourseController.fetchLecture)
+//     .patch(authenticate, CourseLectureValidator.validateBodyOnUpdate, CourseController.updateCourseLecture)
+//     .delete(authenticate, CourseController.deleteCourseLecture);
+
+// router.route('/:slug/lectures/:lectureId/status')
+//     .patch(authenticate, CourseLectureValidator.validateBodyOnStatusUpdate, CourseController.updateLectureStatus);
+
+// router.route('/:slug/modules/:moduleId/lectures/:lectureId/position')
+//     .patch(authenticate, CourseLectureValidator.validateBodyOnPositionUpdate, CourseController.updateLecturePosition);
+
+// PRODUCT CATEGORIES
+router.route('/categories')
+    .post(ProductCategoryValidator.validateBodyOnCreate, ProductCategoryController.createCategory)
+    .get(ProductCategoryController.fetchCategories);
+
+router.route('/categories/:id')
+    .patch(ProductCategoryValidator.validateBodyOnUpdate, ProductCategoryController.updateCategory)
+    .delete(ProductCategoryController.deleteCategory);
+
+router.route('/categories/:id/subcategories')
+    .get(ProductCategoryController.fetchSubcategories);
+
+export default router;

--- a/api/src/routes/v1/index.js
+++ b/api/src/routes/v1/index.js
@@ -1,18 +1,23 @@
 import { Router } from 'express';
 import AuthRoute from './AuthRoute';
 import SubscriptionRoute from './SubscriptionRoute';
+import CourseCategoryRoute from './CourseCategoryRoute';
 import CourseRoute from './CourseRoute';
 import PaymentRoute from './PaymentRoute';
 import ProfileRoute from './ProfileRoute';
+import ProductCategoryRoute from './ProductCategoryRoute';
+import ProductRoute from './ProductRoute';
 
 const router = Router();
 
-
 router.use('/auth', AuthRoute);
 router.use('/subscriptions', SubscriptionRoute);
+router.use('/course-categories', CourseCategoryRoute);
 router.use('/courses', CourseRoute);
 router.use('/payments', PaymentRoute);
 router.use('/me', ProfileRoute);
+router.use('/product-categories', ProductCategoryRoute);
+router.use('/products', ProductRoute);
 
 router.use('/', (req, res) => {
     res.status(200).json({

--- a/api/src/validators/category.js
+++ b/api/src/validators/category.js
@@ -12,6 +12,7 @@ const schemaOnUpdate = Joi.object({
     is_active: Joi.boolean()
 });
 
+/** A Joi schema for validating product and course category data from clients */
 export default {
     validateBodyOnCreate: Validator.validateBody(schemaOnCreate),
     validateBodyOnUpdate: Validator.validateBody(schemaOnUpdate),


### PR DESCRIPTION
#### What does this PR do?
Implement endpoints to interact with product categories ,and also make a change to the base API path to the `course categories` resource

#### Description of Task to be completed?
- implement the `POST /product-categories` endpoint to create a new product category

- implement the `GET /product-categories` endpoint to fetch a list of top-level product categories

- implement the `GET /product-categories/:id/subcategories` to fetch all the subcategories of a given product category

- implement the `PATCH /product-categories/:id` endpoint to update a product category

- implement the `DELETE /product-categories/:id` endpoint to delete a product category

- change the base API path for the course category resource from `/courses/categories` to `/course-categories` to mitigate path param clashes

#### How should this be manually tested?
- clone the repository
- cd into the project directory and run `cd api` to CD into the `api` directory
- see the README.md file in the `api` directory for the preliminary steps
- ensure that a mysql database in installed and running on your device
- see the postman documentation on `Product Categories` and the update on `Course Categories`

#### Any background context you want to provide?
Before this time the base API path to the `course categories` resource was `/courses/categories`, but that presented some issues with clashing path parameters particularly when a user attempts to fetch/update/delete a course by it's slug. In such a scenario, the client could send a request to an endpoint with the following structure - `/courses/:slug`, but the path parameter, `slug`, could be anything even the word "categories".

Hence the need for the new API path to access course categories.

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A
#### Questions:
